### PR TITLE
fix: enable multilingual transcription (Russian, auto-detect)

### DIFF
--- a/Desktop/Sources/DeletedTypeStubs.swift
+++ b/Desktop/Sources/DeletedTypeStubs.swift
@@ -564,8 +564,16 @@ class BleAudioService {
 class AssistantSettings: ObservableObject {
     static let shared = AssistantSettings()
     @Published var transcriptionEnabled: Bool = false
-    @Published var transcriptionLanguage: String = "en"
-    @Published var transcriptionAutoDetect: Bool = false
+    @Published var transcriptionLanguage: String = UserDefaults.standard.string(forKey: "transcription_language") ?? "multi" {
+        didSet {
+            UserDefaults.standard.set(transcriptionLanguage, forKey: "transcription_language")
+        }
+    }
+    @Published var transcriptionAutoDetect: Bool = UserDefaults.standard.object(forKey: "transcription_auto_detect") as? Bool ?? true {
+        didSet {
+            UserDefaults.standard.set(transcriptionAutoDetect, forKey: "transcription_auto_detect")
+        }
+    }
     @Published var batchTranscriptionEnabled: Bool = false
     @Published var vadGateEnabled: Bool = false
     @Published var screenAnalysisEnabled: Bool = false
@@ -576,13 +584,20 @@ class AssistantSettings: ObservableObject {
     }
     @Published var analysisDelay: Int = 3
     @Published var glowOverlayEnabled: Bool = false
-    var effectiveTranscriptionLanguage: String { transcriptionLanguage }
+    var effectiveTranscriptionLanguage: String {
+        if transcriptionAutoDetect {
+            return "multi"  // DeepGram Nova-3 multilingual code-switching
+        }
+        return transcriptionLanguage
+    }
     var effectiveVocabulary: [String] { transcriptionVocabulary }
 
     static var supportedLanguages: [(code: String, name: String)] {
-        [("en", "English"), ("es", "Spanish"), ("fr", "French"), ("de", "German"),
+        [("multi", "Auto-detect (Multilingual)"),
+         ("en", "English"), ("ru", "Русский"), ("es", "Spanish"), ("fr", "French"), ("de", "German"),
          ("it", "Italian"), ("pt", "Portuguese"), ("ja", "Japanese"), ("ko", "Korean"),
-         ("zh", "Chinese"), ("ru", "Russian"), ("ar", "Arabic"), ("hi", "Hindi")]
+         ("zh", "Chinese"), ("ar", "Arabic"), ("hi", "Hindi"),
+         ("nl", "Dutch"), ("uk", "Українська"), ("pl", "Polish"), ("tr", "Turkish")]
     }
     static func supportsAutoDetect(_ language: String) -> Bool { true }
 }

--- a/Desktop/Sources/TranscriptionService.swift
+++ b/Desktop/Sources/TranscriptionService.swift
@@ -296,9 +296,11 @@ class TranscriptionService {
             queryItems.append(URLQueryItem(name: "keyterm", value: term))
         }
 
-        // Add find-and-replace rules for common patterns (URLs, emails, file extensions)
-        for rule in Self.defaultReplacements {
-            queryItems.append(URLQueryItem(name: "replace", value: "\(rule.find):\(rule.replace)"))
+        // Add find-and-replace rules only for English (these are English-specific spoken patterns)
+        if language == "en" || language.hasPrefix("en-") {
+            for rule in Self.defaultReplacements {
+                queryItems.append(URLQueryItem(name: "replace", value: "\(rule.find):\(rule.replace)"))
+            }
         }
 
         components.queryItems = queryItems
@@ -571,9 +573,11 @@ extension TranscriptionService {
             components.queryItems?.append(URLQueryItem(name: "keyterm", value: term))
         }
 
-        // Add find-and-replace rules for common patterns (URLs, emails, file extensions)
-        for rule in defaultReplacements {
-            components.queryItems?.append(URLQueryItem(name: "replace", value: "\(rule.find):\(rule.replace)"))
+        // Add find-and-replace rules only for English (these are English-specific spoken patterns)
+        if language == "en" || language.hasPrefix("en-") {
+            for rule in defaultReplacements {
+                components.queryItems?.append(URLQueryItem(name: "replace", value: "\(rule.find):\(rule.replace)"))
+            }
         }
 
         guard let url = components.url else {


### PR DESCRIPTION
## Summary

Push-to-talk transcription is currently hardcoded to English (`"en"`), making it completely unusable for non-English speakers. This PR fixes the issue by:

- **Defaulting to `"multi"` (multilingual auto-detect)** instead of `"en"` — DeepGram Nova-3 supports automatic language detection for 10 languages including Russian, English, Spanish, French, German, Hindi, Portuguese, Japanese, Italian, and Dutch
- **Persisting language settings to UserDefaults** — previously the language reset to `"en"` on every app restart since `transcriptionLanguage` had no `didSet` persistence (unlike `transcriptionVocabulary` which already persists)
- **Wiring up `transcriptionAutoDetect`** — the property existed but was completely inert; now `effectiveTranscriptionLanguage` returns `"multi"` when auto-detect is enabled
- **Expanding `supportedLanguages`** — added "Auto-detect (Multilingual)", Russian, Ukrainian, Dutch, Polish, and Turkish to the language list
- **Conditionally applying English-only replacements** — find-and-replace rules like `"dot com" → ".com"` are now only sent to DeepGram when language is `"en"`, preventing potential interference with non-English transcription

## Context

The entire transcription pipeline (`AssistantSettings` → `PushToTalkManager` → `TranscriptionService` → DeepGram WebSocket) is fully functional — it just always received `"en"`. Russian (`"ru"`) was even listed in `supportedLanguages` but never surfaced to users via a language picker UI.

DeepGram Nova-3 fully supports Russian both as monolingual (`language=ru`) and via multilingual code-switching (`language=multi`), confirmed in their [Nov 2025 announcement](https://deepgram.com/learn/deepgram-expands-nova-3-with-11-new-languages-across-europe-and-asia).

## Test plan

- [ ] Start Fazm, open Push-to-talk settings
- [ ] Verify language defaults to "Auto-detect (Multilingual)" for new installs
- [ ] Test PTT with Russian speech — should transcribe correctly
- [ ] Test PTT with English speech — should still work
- [ ] Test switching between specific languages (e.g., Russian, English)
- [ ] Restart app — verify language setting persists
- [ ] Test batch transcription mode with non-English speech

## Files changed

- `Desktop/Sources/DeletedTypeStubs.swift` — `AssistantSettings`: default language, persistence, auto-detect logic, expanded language list
- `Desktop/Sources/TranscriptionService.swift` — conditional English-only replacements in both streaming and batch modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)